### PR TITLE
navbar styling

### DIFF
--- a/src/components/Kennel.css
+++ b/src/components/Kennel.css
@@ -4,7 +4,7 @@
     flex-direction: row;
     border: 4px solid grey;
     border-radius: 10px;
-    margin-top: 40px;
+    /* margin-top: 40px; */
     margin-bottom: 40px;
+    padding-top: 40px;
 }
- 

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -2,32 +2,29 @@ import React, { Component } from "react"
 import { Link } from "react-router-dom"
 import "bootstrap/dist/css/bootstrap.min.css"
 
-
 class NavBar extends Component {
     render() {
         return (
-            <nav className="navbar navbar-light fixed-top light-blue flex-md-nowrap p-0 shadow">
-                <ul className="nav nav-pills">
-                    <li className="nav-item">
-                        <Link className="nav-link" to="/">Locations</Link>
-                    </li>
-                    <li className="nav-item">
-                        <Link className="nav-link" to="/animals">Animals</Link>
-                    </li>
-                    <li className="nav-item">
-                        <Link className="nav-link" to="/employees">Employees</Link>
-                    </li>
-                    <li className="nav-item">
-                        <Link className="nav-link" to="/owners">Owners</Link>
-                    </li>
-                    {/* <li className="nav-item">
-                        <Link className="nav-link" to="/friends">Friends</Link>
-                    </li> */}
-                    <li className="nav-item">
-                        <Link className="nav-link" to="/usa">USA</Link>
-                    </li>
-                </ul>
-            </nav>
+            <nav className="navbar navbar-light sticky-top scrolling-navbar text-white bg-dark flex-md-nowrap p-0 shadow" >
+
+                    <ul className="nav nav-pills ">
+                        <li className="nav-item">
+                            <Link className="nav-link" to="/">Locations</Link>
+                        </li>
+                        <li className="nav-item">
+                            <Link className="nav-link" to="/animals">Animals</Link>
+                        </li>
+                        <li className="nav-item">
+                            <Link className="nav-link" to="/employees">Employees</Link>
+                        </li>
+                        <li className="nav-item">
+                            <Link className="nav-link" to="/owners">Owners</Link>
+                        </li>
+                        <li className="nav-item">
+                            <Link className="nav-link" to="/usa">USA</Link>
+                        </li>
+                    </ul>
+                </nav>
         )
     }
 }


### PR DESCRIPTION
# Description
navbar styling.  setting "bg-dark" obscures overlapping elements



## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)


# Testing Instructions for Change Made
to test: click the /usa link in the navbar.  scroll down.  the <body> should fold underneath the navbar and not overlap it. 


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
